### PR TITLE
add real timeout to grub config file

### DIFF
--- a/main/compat-pvgrub/update-pvgrub
+++ b/main/compat-pvgrub/update-pvgrub
@@ -70,7 +70,7 @@ echo "default 0" >> $conf.new
 if [ "$hidden" = "1" ]; then
 	echo "hiddenmenu" >> $conf.new
 fi
-echo "timeout $rtimeout" >> $conf.new
+echo "timeout $timeout" >> $conf.new
 
 lst=0
 


### PR DESCRIPTION
as $rtimeout is undefined, config file ends with 
`timeout `
line, which makes pvgrub fail on int parsing


Using <class 'grub.GrubConf.GrubConfigFile'> to parse /boot/grub/menu.lst
Traceback (most recent call last):
  File "/usr/lib/xen-4.4/bin/pygrub", line 821, in <module>
    chosencfg = run_grub(file, entry, fs, incfg["args"])
  File "/usr/lib/xen-4.4/bin/pygrub", line 611, in run_grub
    curses.wrapper(run_main)
  File "/usr/lib/python2.7/curses/wrapper.py", line 43, in wrapper
    return func(stdscr, *args, **kwds)
  File "/usr/lib/xen-4.4/bin/pygrub", line 597, in run_main
    sel = g.run()
  File "/usr/lib/xen-4.4/bin/pygrub", line 463, in run
    timeout = int(self.cf.timeout)
ValueError: invalid literal for int() with base 10: ''
Traceback (most recent call last):
  File "/usr/lib/xen-4.4/bin/pygrub", line 842, in <module>
    raise RuntimeError, "Unable to find partition containing kernel"

withou pvgrub debug mode you only have `RuntimeError: Unable to find partition containing kernel` message